### PR TITLE
Add Import menu entries

### DIFF
--- a/enhanced_svg/__init__.py
+++ b/enhanced_svg/__init__.py
@@ -12,6 +12,15 @@ from .imports import (
 from . import z_offset
 
 
+def menu_func_import(self, context):
+    """Add the SVG importers to the File > Import menu."""
+    self.layout.operator(ImportSimpleSVGOperator.bl_idname, text="SVG (Simple)")
+    self.layout.operator(ImportSVGOperator.bl_idname, text="SVG (Processed)")
+    self.layout.operator(
+        ImportSVGEmissionOperator.bl_idname, text="SVG (Processed + Emission)"
+    )
+
+
 def register():
     # Register Blender classes
     bpy.utils.register_class(ImportSimpleSVGOperator)
@@ -20,6 +29,8 @@ def register():
     bpy.utils.register_class(SVG_FH_import)
     bpy.utils.register_class(ImportSVGEmissionOperator)
     bpy.utils.register_class(EmissionSVG_FH_import)
+    # Add entries to the File > Import menu
+    bpy.types.TOPBAR_MT_file_import.append(menu_func_import)
     # Register Z offset panel and properties
     z_offset.register()
 
@@ -27,6 +38,8 @@ def register():
 def unregister():
     # Unregister Z offset panel and properties
     z_offset.unregister()
+    # Remove entries from the File > Import menu
+    bpy.types.TOPBAR_MT_file_import.remove(menu_func_import)
     # Unregister Blender classes
     bpy.utils.unregister_class(EmissionSVG_FH_import)
     bpy.utils.unregister_class(ImportSVGEmissionOperator)


### PR DESCRIPTION
Adds the three options to the Import menu, as they were missing, at least in Blender 5.1